### PR TITLE
(possibly fix) `testSuccessfulTempBasal` occasionally crashes

### DIFF
--- a/DashKitTests/DashPumpManagerTests.swift
+++ b/DashKitTests/DashPumpManagerTests.swift
@@ -211,7 +211,9 @@ class DashPumpManagerTests: XCTestCase {
         waitForExpectations(timeout: 3)
 
         XCTAssert(!posStatusUpdates.isEmpty)
-        let lastStatus = posStatusUpdates.last!
+        guard let lastStatus = posStatusUpdates.last else {
+            return
+        }
 
         switch lastStatus.reservoirLevel {
         case .some(.valid(let value)):
@@ -228,10 +230,15 @@ class DashPumpManagerTests: XCTestCase {
         waitForExpectations(timeout: 3)
 
         XCTAssertEqual(2, reportedPumpEvents.count)
-
-        let tempBasalEvent = reportedPumpEvents.last!
+        guard let tempBasalEvent = reportedPumpEvents.last else {
+            return
+        }
         XCTAssertEqual(1.0, tempBasalEvent.dose?.unitsPerHour)
-        XCTAssertNil(tempBasalEvent.dose!.deliveredUnits)
+        XCTAssertNotNil(tempBasalEvent.dose)
+        guard let dose = tempBasalEvent.dose else {
+            return
+        }
+        XCTAssertNil(dose.deliveredUnits)
         XCTAssertEqual(PumpEventType.tempBasal, tempBasalEvent.type)
     }
 

--- a/DashKitTests/DashPumpManagerTests.swift
+++ b/DashKitTests/DashPumpManagerTests.swift
@@ -211,9 +211,7 @@ class DashPumpManagerTests: XCTestCase {
         waitForExpectations(timeout: 3)
 
         XCTAssert(!posStatusUpdates.isEmpty)
-        guard let lastStatus = posStatusUpdates.last else {
-            return
-        }
+        let lastStatus = posStatusUpdates.last!
 
         switch lastStatus.reservoirLevel {
         case .some(.valid(let value)):
@@ -223,6 +221,9 @@ class DashPumpManagerTests: XCTestCase {
         }
         
         pumpEventStorageExpectation = expectation(description: "pumpmanager dose storage")
+        // Sometimes, when a test is run in CI, this expectation is over-fulfilled.
+        // When this happens, the test crashes.  This hopefully would at least avoid that crash.
+        pumpEventStorageExpectation?.assertForOverFulfill = false
         //pumpEventStorageExpectation?.expectedFulfillmentCount = 2
 
         pumpManager.assertCurrentPumpData()
@@ -230,15 +231,10 @@ class DashPumpManagerTests: XCTestCase {
         waitForExpectations(timeout: 3)
 
         XCTAssertEqual(2, reportedPumpEvents.count)
-        guard let tempBasalEvent = reportedPumpEvents.last else {
-            return
-        }
+
+        let tempBasalEvent = reportedPumpEvents.last!
         XCTAssertEqual(1.0, tempBasalEvent.dose?.unitsPerHour)
-        XCTAssertNotNil(tempBasalEvent.dose)
-        guard let dose = tempBasalEvent.dose else {
-            return
-        }
-        XCTAssertNil(dose.deliveredUnits)
+        XCTAssertNil(tempBasalEvent.dose!.deliveredUnits)
         XCTAssertEqual(PumpEventType.tempBasal, tempBasalEvent.type)
     }
 


### PR DESCRIPTION
This is somewhat speculative because I cannot reproduce this locally, but the testSuccessfulTempBasal test occasionally crashes in CI.  This change _might_ fix the crash, although it may make the test fail (at least we would see what failed, though...)