### PR TITLE
Add specific arch dirs to framework search path for PodSK

### DIFF
--- a/DashKit.xcodeproj/project.pbxproj
+++ b/DashKit.xcodeproj/project.pbxproj
@@ -1459,6 +1459,8 @@
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
 					"$(PROJECT_DIR)/dash-sdk-ios",
 					"$(PROJECT_DIR)/dash-sdk-ios/frameworks",
+					"$(PROJECT_DIR)/dash-sdk-ios/frameworks/PodSDK.xcframework/ios-arm64",
+					"$(PROJECT_DIR)/dash-sdk-ios/frameworks/PodSDK.xcframework/ios-x86_64-simulator",
 				);
 				INFOPLIST_FILE = DashKit/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -1495,6 +1497,8 @@
 					"$(PROJECT_DIR)/Carthage/Build/iOS",
 					"$(PROJECT_DIR)/dash-sdk-ios",
 					"$(PROJECT_DIR)/dash-sdk-ios/frameworks",
+					"$(PROJECT_DIR)/dash-sdk-ios/frameworks/PodSDK.xcframework/ios-arm64",
+					"$(PROJECT_DIR)/dash-sdk-ios/frameworks/PodSDK.xcframework/ios-x86_64-simulator",
 				);
 				INFOPLIST_FILE = DashKit/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";


### PR DESCRIPTION
CircleCI, and sometimes local developer builds were failing with `No such module PodSDK`. 
After reproducing locally, I believe the situation described here is what we've been hitting: https://pyckamil.github.io/programming,/xcframework,/xcode/2020/05/09/everything-wrong-with-xcframeworks.html

This can be reverted for Xcode 12