### PR TITLE
LOOP-1833: Dash pump support for calling completion in fetchCurrentPumpData

### DIFF
--- a/DashKit/DashPumpManager.swift
+++ b/DashKit/DashPumpManager.swift
@@ -492,7 +492,7 @@ public class DashPumpManager: PumpManager {
         }
     }
 
-    public func fetchCurrentPumpData(completion: (() -> Void)?) {
+    public func ensureCurrentPumpData(completion: (() -> Void)?) {
 
         guard hasActivePod, state.pendingCommand == nil else {
             return

--- a/DashKit/DashPumpManager.swift
+++ b/DashKit/DashPumpManager.swift
@@ -454,7 +454,7 @@ public class DashPumpManager: PumpManager {
 
     private var isPumpDataStale: Bool {
         let pumpStatusAgeTolerance = TimeInterval(minutes: 6)
-        let pumpDataAge = -(state.lastStatusDate ?? .distantPast).timeIntervalSinceNow
+        let pumpDataAge = -(state.lastStatusDate ?? .distantPast).timeIntervalSince(dateGenerator())
         return pumpDataAge > pumpStatusAgeTolerance
     }
 
@@ -512,6 +512,7 @@ public class DashPumpManager: PumpManager {
                 case .failure(let error):
                     self.log.default("Not recommending Loop because pump data is stale: %@", String(describing: error))
                     self.pumpDelegate.notify({ (delegate) in
+                        completion?()
                         delegate?.pumpManager(self, didError: PumpManagerError.communication(error))
                     })
                 }

--- a/DashKit/DashPumpManager.swift
+++ b/DashKit/DashPumpManager.swift
@@ -492,9 +492,7 @@ public class DashPumpManager: PumpManager {
         }
     }
 
-    
-
-    public func assertCurrentPumpData() {
+    public func fetchCurrentPumpData(completion: (() -> Void)?) {
 
         guard hasActivePod, state.pendingCommand == nil else {
             return
@@ -508,6 +506,7 @@ public class DashPumpManager: PumpManager {
                     self.log.default("Recommending Loop")
                     self.finalizeAndStoreDoses()
                     self.pumpDelegate.notify({ (delegate) in
+                        completion?()
                         delegate?.pumpManagerRecommendsLoop(self)
                     })
                 case .failure(let error):
@@ -522,6 +521,7 @@ public class DashPumpManager: PumpManager {
 
         pumpDelegate.notify { (delegate) in
             self.log.default("Recommending Loop")
+            completion?()
             delegate?.pumpManagerRecommendsLoop(self)
         }
     }

--- a/DashKitTests/DashPumpManagerTests.swift
+++ b/DashKitTests/DashPumpManagerTests.swift
@@ -230,7 +230,7 @@ class DashPumpManagerTests: XCTestCase {
         pumpEventStorageExpectation?.assertForOverFulfill = false
         //pumpEventStorageExpectation?.expectedFulfillmentCount = 2
 
-        pumpManager.assertCurrentPumpData()
+        pumpManager.fetchCurrentPumpData()
 
         waitForExpectations(timeout: 3)
 

--- a/DashKitTests/DashPumpManagerTests.swift
+++ b/DashKitTests/DashPumpManagerTests.swift
@@ -233,7 +233,7 @@ class DashPumpManagerTests: XCTestCase {
         pumpEventStorageExpectation?.assertForOverFulfill = false
         //pumpEventStorageExpectation?.expectedFulfillmentCount = 2
 
-        pumpManager.fetchCurrentPumpData()
+        pumpManager.fetchCurrentPumpData(completion: nil)
 
         waitForExpectations(timeout: 3)
 

--- a/DashKitTests/DashPumpManagerTests.swift
+++ b/DashKitTests/DashPumpManagerTests.swift
@@ -233,7 +233,7 @@ class DashPumpManagerTests: XCTestCase {
         pumpEventStorageExpectation?.assertForOverFulfill = false
         //pumpEventStorageExpectation?.expectedFulfillmentCount = 2
 
-        pumpManager.fetchCurrentPumpData(completion: nil)
+        pumpManager.ensureCurrentPumpData(completion: nil)
 
         waitForExpectations(timeout: 3)
 
@@ -679,15 +679,15 @@ class DashPumpManagerTests: XCTestCase {
         XCTAssertEqual(.resume, resume.type)
     }
     
-    func testFetchCurrentPumpDataStale() {
-        runTestFetchCurrentPumpData(withTimeTravel: .minutes(10))
+    func testEnsureCurrentPumpDataStale() {
+        runTestEnsureCurrentPumpData(withTimeTravel: .minutes(10))
     }
     
-    func testFetchCurrentPumpDataNotStale() {
-        runTestFetchCurrentPumpData(withTimeTravel: 0.0)
+    func testEnsureCurrentPumpDataNotStale() {
+        runTestEnsureCurrentPumpData(withTimeTravel: 0.0)
     }
     
-    private func runTestFetchCurrentPumpData(withTimeTravel delay: TimeInterval) {
+    private func runTestEnsureCurrentPumpData(withTimeTravel delay: TimeInterval) {
         timeTravel(0)
         let statusExpectation = expectation(description: "status")
         pumpManager.getPodStatus { _ in
@@ -697,12 +697,12 @@ class DashPumpManagerTests: XCTestCase {
 
         timeTravel(delay)
         
-        let fetchCurrentPumpDataCompletionCalledExpectation = expectation(description: "fetchCurrentPumpData calls completion")
-        self.pumpManager.fetchCurrentPumpData {
-            fetchCurrentPumpDataCompletionCalledExpectation.fulfill()
+        let ensureCurrentPumpDataCompletionCalledExpectation = expectation(description: "ensureCurrentPumpData calls completion")
+        self.pumpManager.ensureCurrentPumpData {
+            ensureCurrentPumpDataCompletionCalledExpectation.fulfill()
         }
 
-        wait(for: [fetchCurrentPumpDataCompletionCalledExpectation], timeout: 1.0)
+        wait(for: [ensureCurrentPumpDataCompletionCalledExpectation], timeout: 1.0)
     }
     
 }


### PR DESCRIPTION
This uncovered a few strange unit test "bugs" in DashKit that I tried to resolve.  I'm very interested in @ps2 's review here.