### PR TITLE
[LOOP-1558] Report reservoir level

### DIFF
--- a/DashKit/DashPumpManager.swift
+++ b/DashKit/DashPumpManager.swift
@@ -197,10 +197,8 @@ public class DashPumpManager: PumpManager {
         }
         
         pumpDelegate.notify { (delegate) in
-            if oldValue != nil,
-                newValue.reservoirLevel != oldValue.reservoirLevel,
-                let reservoirLevel = newValue.reservoirLevel,
-                case .valid(let reservoirRemaining) = reservoirLevel
+            if newValue.reservoirLevel != oldValue.reservoirLevel,
+                case .valid(let reservoirRemaining) = newValue.reservoirLevel
             {
                 delegate?.pumpManager(self,
                                       didReadReservoirValue: Double(reservoirRemaining),

--- a/DashKit/DashPumpManager.swift
+++ b/DashKit/DashPumpManager.swift
@@ -197,6 +197,17 @@ public class DashPumpManager: PumpManager {
         }
         
         pumpDelegate.notify { (delegate) in
+            if oldValue != nil,
+                newValue.reservoirLevel != oldValue.reservoirLevel,
+                let reservoirLevel = newValue.reservoirLevel,
+                case .valid(let reservoirRemaining) = reservoirLevel
+            {
+                delegate?.pumpManager(self,
+                                      didReadReservoirValue: Double(reservoirRemaining),
+                                      at: self.dateGenerator(),
+                                      completion: { _ in })
+            }
+            
             delegate?.pumpManagerDidUpdateState(self)
         }
         
@@ -1147,6 +1158,9 @@ public class DashPumpManager: PumpManager {
 
         #if targetEnvironment(simulator)
         let mockPodCommManager = MockPodCommManager.shared
+        if let reservoirUnitsRemaining = state.reservoirLevel?.rawValue {
+            mockPodCommManager.podStatus.reservoirUnitsRemaining = reservoirUnitsRemaining
+        }
         #endif
 
         if let podCommManager = podCommManager {

--- a/DashKit/Mocks/MockPodCommManager.swift
+++ b/DashKit/Mocks/MockPodCommManager.swift
@@ -25,7 +25,11 @@ public class MockPodCommManager: PodCommManagerProtocol {
     var lastBasalProgram: BasalProgram?
     var lastTempBasal: TempBasal?
 
-    var podStatus: MockPodStatus
+    public var podStatus: MockPodStatus {
+        didSet {
+            dashPumpManager?.getPodStatus(completion: { _ in })
+        }
+    }
         
     public var silencedAlerts: [PodAlerts] = []
     

--- a/DashKitUI/Views/MockPodSettingsView.swift
+++ b/DashKitUI/Views/MockPodSettingsView.swift
@@ -53,6 +53,10 @@ struct MockPodSettingsView: View {
                 sendProgramErrorPicker
                 unacknowledgedCommandRetryResultPicker
             }
+            
+            Section(header: Text("Reservoir Remaining").font(.headline).foregroundColor(Color.primary)) {
+                reservoirRemainingEntry
+            }
         }
         .navigationBarTitle("Mock Pod Settings")
     }
@@ -87,10 +91,28 @@ struct MockPodSettingsView: View {
                 Text(self.podCommErrorFormatted(PodCommError.simulatedErrors[$0]))
             }
         }
-
-
+    }
+    
+    var reservoirRemainingEntry: some View {
+        let reservoirRemaining = Binding(
+            get: { self.mockPodCommManager.podStatus.reservoirUnitsRemaining / Int(Pod.podSDKInsulinMultiplier) },
+            set: { self.mockPodCommManager.podStatus.reservoirUnitsRemaining = $0 * Int(Pod.podSDKInsulinMultiplier) }
+        )
+        
+        return MockPodReservoirRemainingEntryView(reservoirRemaining: reservoirRemaining)
     }
 
+}
+
+struct MockPodReservoirRemainingEntryView: View {
+    @Binding var reservoirRemaining: Int
+    
+    var body: some View {
+        TextField("Enter reservoir remaining value",
+                  value: $reservoirRemaining,
+                  formatter: NumberFormatter())
+            .keyboardType(.numberPad)
+    }
 }
 
 struct MockPodSettingsView_Previews: PreviewProvider {


### PR DESCRIPTION
https://tidepool.atlassian.net/browse/LOOP-1558

Includes:
- `DashPumpManager` reports reservoir level when state is set
- `MockPodSettings` includes a field to set the reservoir remaining value