### PR TITLE
LOOP-2325: iOS14: use InsetGroupedListStyle for iOS 14

### DIFF
--- a/DashKitUI/Views/DashSettingsView.swift
+++ b/DashKitUI/Views/DashSettingsView.swift
@@ -18,7 +18,6 @@ struct DashSettingsView<Model>: View where Model: DashSettingsViewModelProtocol 
     
     @State private var showSuspendOptions = false;
     
-    @Environment(\.horizontalSizeClass) var horizontalSizeClass
     @Environment(\.guidanceColors) var guidanceColors
     @Environment(\.insulinTintColor) var insulinTintColor
     
@@ -283,8 +282,7 @@ struct DashSettingsView<Model>: View where Model: DashSettingsViewModelProtocol 
 
         }
         .alert(isPresented: $viewModel.alertIsPresented, content: { alert(for: viewModel.activeAlert!) })
-        .listStyle(GroupedListStyle())
-        .environment(\.horizontalSizeClass, self.horizontalSizeClass)
+        .insetGroupedListStyle()
         .navigationBarItems(trailing: doneButton)
         .navigationBarTitle("Omnipod", displayMode: .automatic)
         


### PR DESCRIPTION
This adds a View modifier that will use InsetGroupedListStyle for iOS 14, but fall back to the old GroupedListStyle with horizontalSizeClass override hack for prior iOS versions.

[LOOP-2325](https://tidepool.atlassian.net/browse/LOOP-2325)