### PR TITLE
LOOP-1234, LOOP-1236, LOOP-1238 : Alarms and SystemError

### DIFF
--- a/DashKit/DashPumpManager.swift
+++ b/DashKit/DashPumpManager.swift
@@ -166,6 +166,16 @@ open class DashPumpManager: PumpManager {
             return nil
         }
     }
+    
+    private func pumpLifecycleProgress(for state: DashPumpManagerState) -> PumpManagerStatus.PumpLifecycleProgress? {
+        switch podCommManager.podCommState {
+        // TODO: Handle active lifecycle progress
+        case .alarm:
+            return PumpManagerStatus.PumpLifecycleProgress(percentComplete: 100, progressState: .critical)
+        default:
+            return nil
+        }
+    }
 
     
     private func status(for state: DashPumpManagerState) -> PumpManagerStatus {
@@ -176,6 +186,7 @@ open class DashPumpManager: PumpManager {
             basalDeliveryState: basalDeliveryState(for: state),
             bolusState: bolusState(for: state),
             pumpStatusHighlight: pumpStatusHighlight(for: state),
+            pumpLifecycleProgress: pumpLifecycleProgress(for: state),
             deliveryIsUncertain: state.pendingCommand != nil
         )
     }

--- a/DashKit/DashPumpManagerState.swift
+++ b/DashKit/DashPumpManagerState.swift
@@ -200,10 +200,7 @@ public struct DashPumpManagerState: RawRepresentable, Equatable {
             "activeAlerts": activeAlerts.rawValue,
         ]
         
-        if let rawLastPodCommState = try? JSONEncoder().encode(lastPodCommState) {
-            rawValue["lastPodCommState"] = rawLastPodCommState
-        }
-
+        rawValue["lastPodCommState"] = try? JSONEncoder().encode(lastPodCommState)
         rawValue["suspendState"] = suspendState?.rawValue
         rawValue["lastStatusDate"] = lastStatusDate
         rawValue["reservoirLevel"] = reservoirLevel?.rawValue

--- a/DashKit/DashPumpManagerState.swift
+++ b/DashKit/DashPumpManagerState.swift
@@ -41,6 +41,8 @@ public struct DashPumpManagerState: RawRepresentable, Equatable {
     
     public var alarmCode: AlarmCode?
     
+    public var lastPodCommState: PodCommState
+    
     public var unfinalizedBolus: UnfinalizedDose?
     public var unfinalizedTempBasal: UnfinalizedDose?
 
@@ -91,7 +93,7 @@ public struct DashPumpManagerState: RawRepresentable, Equatable {
         return dateGeneratorWrapper.dateGenerator()
     }
 
-    public init?(basalRateSchedule: BasalRateSchedule, maximumTempBasalRate: Double, dateGenerator: @escaping () -> Date = Date.init) {
+    public init?(basalRateSchedule: BasalRateSchedule, maximumTempBasalRate: Double, lastPodCommState: PodCommState, dateGenerator: @escaping () -> Date = Date.init) {
         self.timeZone = basalRateSchedule.timeZone
         guard let basalProgram = BasalProgram(items: basalRateSchedule.items) else {
             return nil
@@ -102,6 +104,7 @@ public struct DashPumpManagerState: RawRepresentable, Equatable {
         self.suspendState = .resumed(dateGenerator())
         self.maximumTempBasalRate = maximumTempBasalRate
         self.activeAlerts = []
+        self.lastPodCommState = lastPodCommState
     }
 
 
@@ -177,6 +180,14 @@ public struct DashPumpManagerState: RawRepresentable, Equatable {
         } else {
             self.pendingCommand = nil
         }
+        
+        if let rawLastPodCommState = rawValue["lastPodCommState"] as? Data,
+           let lastPodCommState = try? JSONDecoder().decode(PodCommState.self, from: rawLastPodCommState)
+        {
+            self.lastPodCommState = lastPodCommState
+        } else {
+            self.lastPodCommState = .noPod
+        }
     }
 
     public var rawValue: RawValue {
@@ -186,8 +197,12 @@ public struct DashPumpManagerState: RawRepresentable, Equatable {
             "finishedDoses": finishedDoses.map( { $0.rawValue }),
             "basalProgram": basalProgram.rawValue,
             "maximumTempBasalRate": maximumTempBasalRate,
-            "activeAlerts": activeAlerts.rawValue
+            "activeAlerts": activeAlerts.rawValue,
         ]
+        
+        if let rawLastPodCommState = try? JSONEncoder().encode(lastPodCommState) {
+            rawValue["lastPodCommState"] = rawLastPodCommState
+        }
 
         rawValue["suspendState"] = suspendState?.rawValue
         rawValue["lastStatusDate"] = lastStatusDate

--- a/DashKit/Extensions/AlarmCode.swift
+++ b/DashKit/Extensions/AlarmCode.swift
@@ -32,7 +32,7 @@ extension AlarmCode {
             // extracted to be provided as a dependency
             return LocalizedString("Remove Pod Now. Call Customer Care at 1 800-591-3455", comment: "The body of AlarmCode.other notification")
         default:
-            return LocalizedString("Insulin delivery stopped.\nChange Pod now.", comment: "The default notification body for AlarmCodes")
+            return LocalizedString("Insulin delivery stopped. Change Pod now.", comment: "The default notification body for AlarmCodes")
         }
     }
 }

--- a/DashKit/Extensions/AlarmCode.swift
+++ b/DashKit/Extensions/AlarmCode.swift
@@ -15,7 +15,7 @@ extension AlarmCode {
         case .autoOff:
             return LocalizedString("Auto Off Alarm", comment: "The title for Auto-Off alarm notification")
         case .emptyReservoir:
-            return LocalizedString("Empty Reservoir Alarm", comment: "The title for Empty Reservoir alarm notification")
+            return LocalizedString("Empty Reservoir", comment: "The title for Empty Reservoir alarm notification")
         case .occlusion:
             return LocalizedString("Occlusion Detected", comment: "The title for Occlusion alarm notification")
         case .other:
@@ -31,10 +31,8 @@ extension AlarmCode {
             // TODO: This string is up for review; also, if phone number is used in final string, it should be
             // extracted to be provided as a dependency
             return LocalizedString("Remove Pod Now. Call Customer Care at 1 800-591-3455", comment: "The body of AlarmCode.other notification")
-        case .podExpired:
-            return LocalizedString("Insulin delivery stopped.\nChange Pod now.", comment: "The notification body for podExpired AlarmCode")
         default:
-            return LocalizedString("Insulin delivery stopped.\nChange Pod now.", comment: "The notification body for unknown AlarmCode")
+            return LocalizedString("Insulin delivery stopped.\nChange Pod now.", comment: "The default notification body for AlarmCodes")
         }
     }
 }

--- a/DashKit/Extensions/AlarmCode.swift
+++ b/DashKit/Extensions/AlarmCode.swift
@@ -19,7 +19,7 @@ extension AlarmCode {
         case .occlusion:
             return LocalizedString("Occlusion Detected", comment: "The title for Occlusion alarm notification")
         case .other:
-            return LocalizedString("Call Customer Care", comment: "The title for AlarmCode.other notification")
+            return LocalizedString("Pod Error", comment: "The title for AlarmCode.other notification")
         case .podExpired:
             return LocalizedString("Pod Expired", comment: "The title for Pod Expired alarm notification")
         }

--- a/DashKit/Mocks/MockPodCommManager.swift
+++ b/DashKit/Mocks/MockPodCommManager.swift
@@ -37,10 +37,14 @@ public class MockPodCommManager: PodCommManagerProtocol {
 
     public var podCommState: PodCommState {
         get {
-            return lockedPodCommState.value
+            if let podStatus = podStatus {
+                return podStatus.podCommState
+            } else {
+                return .noPod
+            }
         }
         set {
-            lockedPodCommState.value = newValue
+            podStatus?.podCommState = newValue
             self.dashPumpManager?.podCommManager(self, podCommStateDidChange: podCommState)
             notifyObservers()
         }
@@ -243,6 +247,12 @@ public class MockPodCommManager: PodCommManagerProtocol {
         let alarmDetail = podStatus.alarmDetail!
         self.podCommState = .alarm(alarmDetail)
         self.dashPumpManager?.podCommManager(self, didAlarm: alarmDetail)
+    }
+    
+    public func triggerSystemError() {
+        let systemError = Self.systemError
+        self.podCommState = .systemError(systemError)
+        dashPumpManager?.podCommManagerHasSystemError(error: systemError)
     }
 
     public func discardPod(completion: @escaping (PodCommResult<Bool>) -> ()) {
@@ -457,6 +467,11 @@ public class MockPodCommManager: PodCommManagerProtocol {
             self.lockedPodCommState = Locked(.noPod)
         }
         self.dateGenerator = dateGenerator ?? { return Date() }
+    }
+    
+    public static var systemError: SystemError {
+        let json = "{\"error\":\"dataCorruption\",\"referenceCode\":\"01-mock-pod-003\"}"
+        return try! JSONDecoder().decode(SystemError.self, from: json.data(using: .utf8)!)
     }
 }
 

--- a/DashKit/Mocks/MockPodCommManager.swift
+++ b/DashKit/Mocks/MockPodCommManager.swift
@@ -37,11 +37,7 @@ public class MockPodCommManager: PodCommManagerProtocol {
 
     public var podCommState: PodCommState {
         get {
-            if let podStatus = podStatus {
-                return podStatus.podCommState
-            } else {
-                return .noPod
-            }
+            return podStatus?.podCommState ?? .noPod
         }
         set {
             podStatus?.podCommState = newValue

--- a/DashKit/Mocks/MockPodStatus.swift
+++ b/DashKit/Mocks/MockPodStatus.swift
@@ -344,53 +344,18 @@ extension MockPodStatus: RawRepresentable {
             "lastDeliveryUpdate": lastDeliveryUpdate
         ]
         
-        if let basalProgram = basalProgram {
-            rawValue["basalProgram"] = basalProgram.rawValue
-        }
-        
-        if let basalProgramStartDate = basalProgramStartDate {
-            rawValue["basalProgramStartDate"] = basalProgramStartDate
-        }
-        
-        if let basalProgramStartOffset = basalProgramStartOffset {
-            rawValue["basalProgramStartOffset"] = basalProgramStartOffset
-        }
-        
-        if let alarmCode = alarmCode {
-            rawValue["alarmCode"] = alarmCode.rawValue
-        }
-        
-        if let alarmDescription = alarmDescription {
-            rawValue["alarmDescription"] = alarmDescription
-        }
-        
-        if let occlusionType = occlusionType {
-            rawValue["occlusionType"] = occlusionType.rawValue
-        }
-        
-        if let didErrorOccuredFetchingBolusInfo = didErrorOccuredFetchingBolusInfo {
-            rawValue["didErrorOccuredFetchingBolusInfo"] = didErrorOccuredFetchingBolusInfo
-        }
-
-        if let wasBolusActiveWhenPodAlarmed = wasBolusActiveWhenPodAlarmed {
-            rawValue["wasBolusActiveWhenPodAlarmed"] = wasBolusActiveWhenPodAlarmed
-        }
-
-        if let podStateWhenPodAlarmed = podStateWhenPodAlarmed {
-            rawValue["podStateWhenPodAlarmed"] = podStateWhenPodAlarmed.rawValue
-        }
-
-        if let alarmDate = alarmDate {
-            rawValue["alarmDate"] = alarmDate
-        }
-
-        if let alarmReferenceCode = alarmReferenceCode {
-            rawValue["alarmReferenceCode"] = alarmReferenceCode
-        }
-        
-        if let rawPodCommState = try? JSONEncoder().encode(podCommState) {
-            rawValue["podCommState"] = rawPodCommState
-        }
+        rawValue["basalProgram"] = basalProgram?.rawValue
+        rawValue["basalProgramStartDate"] = basalProgramStartDate
+        rawValue["basalProgramStartOffset"] = basalProgramStartOffset
+        rawValue["alarmCode"] = alarmCode?.rawValue
+        rawValue["alarmDescription"] = alarmDescription
+        rawValue["occlusionType"] = occlusionType?.rawValue
+        rawValue["didErrorOccuredFetchingBolusInfo"] = didErrorOccuredFetchingBolusInfo
+        rawValue["wasBolusActiveWhenPodAlarmed"] = wasBolusActiveWhenPodAlarmed
+        rawValue["podStateWhenPodAlarmed"] = podStateWhenPodAlarmed?.rawValue
+        rawValue["alarmDate"] = alarmDate
+        rawValue["alarmReferenceCode"] = alarmReferenceCode
+        rawValue["podCommState"] = try? JSONEncoder().encode(podCommState)
 
         return rawValue
     }

--- a/DashKit/Mocks/MockPodStatus.swift
+++ b/DashKit/Mocks/MockPodStatus.swift
@@ -42,6 +42,8 @@ public struct MockPodStatus: PodStatus, Equatable {
             }
         }
     }
+    
+    public var podCommState: PodCommState
 
     public var timeElapsedSinceActivation: TimeInterval {
         return Date().timeIntervalSince(activationDate)
@@ -125,7 +127,8 @@ public struct MockPodStatus: PodStatus, Equatable {
                 bolusUnitsRemaining: Int,
                 initialInsulinAmount: Double,
                 insulinDelivered: Double = 0,
-                basalProgram: BasalProgram? = nil)
+                basalProgram: BasalProgram? = nil,
+                podCommState: PodCommState = .active)
     {
         self.activationDate = activationDate
         self.podState = podState
@@ -137,6 +140,7 @@ public struct MockPodStatus: PodStatus, Equatable {
         self.insulinDelivered = insulinDelivered
         self.lastDeliveryUpdate = Date()
         self.basalProgram = basalProgram
+        self.podCommState = podCommState
     }
     
     public static var normal: MockPodStatus {
@@ -255,7 +259,9 @@ extension MockPodStatus: RawRepresentable {
             let bolusUnitsRemaining = rawValue["bolusUnitsRemaining"] as? Int,
             let insulinDelivered = rawValue["insulinDelivered"] as? Double,
             let initialInsulinAmount = rawValue["initialInsulinAmount"] as? Double,
-            let lastDeliveryUpdate = rawValue["lastDeliveryUpdate"] as? Date
+            let lastDeliveryUpdate = rawValue["lastDeliveryUpdate"] as? Date,
+            let rawPodCommState = rawValue["podCommState"] as? Data,
+            let podCommState = try? JSONDecoder().decode(PodCommState.self, from: rawPodCommState)
             else
         {
             return nil
@@ -270,6 +276,7 @@ extension MockPodStatus: RawRepresentable {
         self.insulinDelivered = insulinDelivered
         self.initialInsulinAmount = initialInsulinAmount
         self.lastDeliveryUpdate = lastDeliveryUpdate
+        self.podCommState = podCommState
         
         if let rawBasalProgram = rawValue["basalProgram"] as? BasalProgram.RawValue,
            let basalProgram = BasalProgram(rawValue: rawBasalProgram)
@@ -321,7 +328,7 @@ extension MockPodStatus: RawRepresentable {
 
         if let alarmReferenceCode = rawValue["alarmReferenceCode"] as? String {
             self.alarmReferenceCode = alarmReferenceCode
-        }
+        }        
     }
     
     public var rawValue: RawValue {
@@ -379,6 +386,10 @@ extension MockPodStatus: RawRepresentable {
 
         if let alarmReferenceCode = alarmReferenceCode {
             rawValue["alarmReferenceCode"] = alarmReferenceCode
+        }
+        
+        if let rawPodCommState = try? JSONEncoder().encode(podCommState) {
+            rawValue["podCommState"] = rawPodCommState
         }
 
         return rawValue

--- a/DashKit/Pod.swift
+++ b/DashKit/Pod.swift
@@ -52,4 +52,7 @@ public struct Pod {
     
     // Default low reservoir alert limit in Units
     public static let defaultLowReservoirLimit: Double = 10
+    
+    // Support phone number (TODO: get from SDK?)
+    public static let supportPhoneNumber: String = "1-800-591-3455"
 }

--- a/DashKit/PodAlert.swift
+++ b/DashKit/PodAlert.swift
@@ -109,10 +109,7 @@ public enum PodAlert: String {
 
     
     var actionButtonLabel: String {
-        switch self {
-        default:
-            return LocalizedString("Ok", comment: "Action button default text for PodAlerts")
-        }
+        return LocalizedString("Ok", comment: "Action button default text for PodAlerts")
     }
     
     var foregroundContent: Alert.Content {

--- a/DashKit/PodAlert.swift
+++ b/DashKit/PodAlert.swift
@@ -80,11 +80,11 @@ public enum PodAlert: String {
         case .userPodExpiration:
             return LocalizedString("Pod Expiration Reminder", comment: "Alert content body for userPodExpiration pod alert")
         case .podExpiring:
-            return LocalizedString("Change Pod now.\nPod has been active for 72 hours.", comment: "Alert content body for podExpiring pod alert")
+            return LocalizedString("Change Pod now. Pod has been active for 72 hours.", comment: "Alert content body for podExpiring pod alert")
         case .podExpireImminent:
-            return LocalizedString("Change Pod now.\nInsulin delivery will stop in 1 hour.", comment: "Alert content body for podExpireImminent pod alert")
+            return LocalizedString("Change Pod now. Insulin delivery will stop in 1 hour.", comment: "Alert content body for podExpireImminent pod alert")
         case .lowReservoir:
-            return LocalizedString("10 U insulin or less remaining in Pod.\nChange Pod soon.", comment: "Alert content body for lowReservoir pod alert")
+            return LocalizedString("10 U insulin or less remaining in Pod. Change Pod soon.", comment: "Alert content body for lowReservoir pod alert")
         case .suspendInProgress:
             return LocalizedString("Suspend In Progress Reminder", comment: "Alert content body for suspendInProgress pod alert")
         case .suspendEnded:
@@ -110,10 +110,8 @@ public enum PodAlert: String {
     
     var actionButtonLabel: String {
         switch self {
-        case .suspendEnded:
-            return LocalizedString("OK", comment: "Action button text to acknowledge pump resume")
         default:
-            return LocalizedString("Acknowledge", comment: "Action button default text for PodAlerts")
+            return LocalizedString("Ok", comment: "Action button default text for PodAlerts")
         }
     }
     

--- a/DashKit/PodStatusExtension.swift
+++ b/DashKit/PodStatusExtension.swift
@@ -104,11 +104,7 @@ public extension SystemErrorCode {
 
 public extension SystemError {
     var localizedDescription: String {
-        if self.referenceCode.count > 0 {
-            return String(format: LocalizedString("%1$@: %2$@", comment: "Format string for error description for PodCommError.systemError (1: system error code description) (2: support reference code)"), self.errorCode.localizedDescription, self.referenceCode)
-        } else {
-            return self.errorCode.localizedDescription
-        }
+        return String(format: LocalizedString("Remove Pod now.\nCall Insulet customer care: %1$@\nRef: %2$@", comment: "Format string for error description for PodCommError.systemError (1: support number) (2: support reference code)"), Pod.supportPhoneNumber, self.referenceCode)
     }
     
     var recoverySuggestion: String {

--- a/DashKitUI/View Controllers/DashUICoordinator.swift
+++ b/DashKitUI/View Controllers/DashUICoordinator.swift
@@ -128,7 +128,7 @@ class DashUICoordinator: UINavigationController, PumpManagerSetupViewController,
                 let basalRateSchedule = basalSchedule,
                 let pumpManagerType = pumpManagerType,
                 let maxBasalRateUnitsPerHour = maxBasalRateUnitsPerHour,
-                let pumpManagerState = DashPumpManagerState(basalRateSchedule: basalRateSchedule, maximumTempBasalRate: maxBasalRateUnitsPerHour)
+                let pumpManagerState = DashPumpManagerState(basalRateSchedule: basalRateSchedule, maximumTempBasalRate: maxBasalRateUnitsPerHour, lastPodCommState: .noPod)
             {
                 let pumpManager = pumpManagerType.init(state: pumpManagerState)
                 self.pumpManager = pumpManager

--- a/DashKitUI/View Models/MockPodSettingsViewModel.swift
+++ b/DashKitUI/View Models/MockPodSettingsViewModel.swift
@@ -68,6 +68,10 @@ class MockPodSettingsViewModel: ObservableObject, Identifiable {
     func triggerAlarm(_ alarm: SimulatedPodAlarm) {
         mockPodCommManager.triggerAlarm(alarm.alarmCode)
     }
+    
+    func triggerSystemError() {
+        mockPodCommManager.triggerSystemError()
+    }
 }
 
 extension MockPodSettingsViewModel: MockPodCommManagerObserver {

--- a/DashKitUI/Views/DashSettingsView.swift
+++ b/DashKitUI/Views/DashSettingsView.swift
@@ -172,9 +172,11 @@ struct DashSettingsView<Model>: View where Model: DashSettingsViewModelProtocol 
                         reservoirStatus
                     }
                 }
-                self.viewModel.systemErrorDescription.map { (systemErrorDescription) in
+                
+                if let systemErrorDescription = viewModel.systemErrorDescription {
                     Text(systemErrorDescription)
-                        .foregroundColor(Color.secondary)
+                        .lineLimit(nil)
+                        .fixedSize(horizontal: false, vertical: true)
                 }
             }.padding(.bottom, 8)
             

--- a/DashKitUI/Views/MockPodSettingsView.swift
+++ b/DashKitUI/Views/MockPodSettingsView.swift
@@ -21,6 +21,8 @@ struct MockPodSettingsView: View {
     
     @State private var showAlarmActions: Bool = false
     @State private var selectedAlarm: SimulatedPodAlarm?
+    
+    @State private var showSystemErrorActions: Bool = false
 
     func podCommErrorFormatted(_ error: PodCommError?) -> String {
         if let error = error {
@@ -100,6 +102,29 @@ struct MockPodSettingsView: View {
                         .default(Text("Issue in 15s")) { DispatchQueue.main.asyncAfter(deadline: .now() + 15) {
                             self.model.triggerAlarm(selectedAlarm!)
                         } },
+                    ]
+                )
+            }
+            Section(header: Text("System Errors").font(.headline).foregroundColor(Color.primary)) {
+                Button(action: {
+                    self.showSystemErrorActions = true
+                }) {
+                    Text("Trigger System Error")
+                }
+            }
+            .actionSheet(isPresented: $showSystemErrorActions) {
+                ActionSheet(
+                    title: Text("System Error"),
+                    buttons: [
+                        .cancel(),
+                        .default(Text("Issue Immediately")) {
+                            self.model.triggerSystemError()
+                        },
+                        .default(Text("Issue in 15s")) {
+                            DispatchQueue.main.asyncAfter(deadline: .now() + 15) {
+                                self.model.triggerSystemError()
+                            }
+                        },
                     ]
                 )
             }


### PR DESCRIPTION
Includes:

https://tidepool.atlassian.net/browse/LOOP-1234 (Empty Reservoir)
https://tidepool.atlassian.net/browse/LOOP-1236 (Pod Error)
https://tidepool.atlassian.net/browse/LOOP-1238 (System Error)

UI for triggering SystemError in Pod demo
SystemError Handling in DashPumpManager
Show expired lifecycle in hud on pod expired.