### PR TITLE
LOOP-1234 Fix alert id

### DIFF
--- a/DashKit/DashPumpManager.swift
+++ b/DashKit/DashPumpManager.swift
@@ -25,7 +25,7 @@ open class DashPumpManager: PumpManager {
 
     static let podAlarmNotificationIdentifier = "DASH:\(LoopNotificationCategory.pumpFault.rawValue)"
     
-    static let systemErrorNotificationIdentifier = "DASH:\(LoopNotificationCategory.systemError.rawValue)"
+    static let systemErrorNotificationIdentifier = "DASH:system-error"
     
     public var podCommManager: PodCommManagerProtocol
     


### PR DESCRIPTION
This is a follow-on to https://github.com/tidepool-org/DashKit/pull/79, which inadvertently added a reference to a LoopKit enum case that wasn't correct.