### PR TITLE
Use INSSDK as xcframework

### DIFF
--- a/DashKit.xcodeproj/project.pbxproj
+++ b/DashKit.xcodeproj/project.pbxproj
@@ -40,7 +40,6 @@
 		C10C758322C404B700CCC20F /* PodCommManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C10C758222C404B700CCC20F /* PodCommManager.swift */; };
 		C10CFCFA2584137200CD89D8 /* OSLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1ACF43E22A1F9A700F7DDB4 /* OSLog.swift */; };
 		C10CFCFD2584137200CD89D8 /* LoopKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C1FE2E3922EA0B360035DCA0 /* LoopKit.framework */; };
-		C10CFCFE2584137200CD89D8 /* INSSDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C1FE2E5622EA0DDB0035DCA0 /* INSSDK.framework */; };
 		C10CFCFF2584137200CD89D8 /* LoopKitUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C1FE2E3B22EA0B360035DCA0 /* LoopKitUI.framework */; };
 		C10CFD002584137200CD89D8 /* DashKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C1E753D9226928F700A0BC48 /* DashKit.framework */; platformFilter = ios; };
 		C10CFD012584137200CD89D8 /* DashKitUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C107D15322694B9C00D63775 /* DashKitUI.framework */; platformFilter = ios; };
@@ -49,7 +48,6 @@
 		C10D1D7824117E990007ABF7 /* PodPairer.swift in Sources */ = {isa = PBXBuildFile; fileRef = C10D1D74241168060007ABF7 /* PodPairer.swift */; };
 		C10D6121240D65300081FFFA /* PairPodViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C10D6120240D65300081FFFA /* PairPodViewModel.swift */; };
 		C10EF92E24044C000091392C /* SettingsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = C10EF92C24044B560091392C /* SettingsProvider.swift */; };
-		C11097CE238F14A4004F1A04 /* PodSDK.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = C11097CD238F14A4004F1A04 /* PodSDK.xcframework */; };
 		C115A5FB245B4069005ACEF7 /* MockPodAlarm.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A9194A2433917E008D216E /* MockPodAlarm.swift */; };
 		C115A5FC245B41B9005ACEF7 /* MockPodStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1562F8C2416A945006952D6 /* MockPodStatus.swift */; };
 		C118C71D25A7D7550029C451 /* MockPodSettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C118C71C25A7D7550029C451 /* MockPodSettingsViewModel.swift */; };
@@ -58,8 +56,6 @@
 		C1201E3123EDF498002DA84A /* Image.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1201E3023EDF498002DA84A /* Image.swift */; };
 		C1201E3F23EE1B03002DA84A /* RegisterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1201E3E23EE1B03002DA84A /* RegisterView.swift */; };
 		C1245D4C24B78FFA0065120F /* PodAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1245D4B24B78FFA0065120F /* PodAlert.swift */; };
-		C1245D4D24B8D5510065120F /* PodSDK.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = C11097CD238F14A4004F1A04 /* PodSDK.xcframework */; };
-		C1245D4E24B8D59B0065120F /* PodSDK.xcframework in CopyFiles */ = {isa = PBXBuildFile; fileRef = C11097CD238F14A4004F1A04 /* PodSDK.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		C127160C237A07B60093DAB7 /* UnfinalizedDoseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C127160B237A07B60093DAB7 /* UnfinalizedDoseTests.swift */; };
 		C12A06A123F217A40052195C /* RegistrationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C12A06A023F217A40052195C /* RegistrationViewModel.swift */; };
 		C12A06AA23F2EFED0052195C /* MockRegistrationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C12A06A923F2EFED0052195C /* MockRegistrationManager.swift */; };
@@ -92,8 +88,6 @@
 		C16DA83622E7C6F2008624C2 /* DashKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C1E753D9226928F700A0BC48 /* DashKit.framework */; platformFilter = ios; };
 		C16DA85822E93973008624C2 /* DashKitUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C107D15322694B9C00D63775 /* DashKitUI.framework */; platformFilter = ios; };
 		C171758C2437AFF200199ABC /* CheckInsertedCannulaView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C171758B2437AFF200199ABC /* CheckInsertedCannulaView.swift */; };
-		C176FE3524350581005258CD /* INSSDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C1FE2E5622EA0DDB0035DCA0 /* INSSDK.framework */; };
-		C176FE3624350651005258CD /* INSSDK.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = C1FE2E5622EA0DDB0035DCA0 /* INSSDK.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		C188E42624C61E98002701AB /* PodAlerts.swift in Sources */ = {isa = PBXBuildFile; fileRef = C188E42524C61E98002701AB /* PodAlerts.swift */; };
 		C194114E228DBEC000E886DD /* PodSetupCompleteViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C194114D228DBEC000E886DD /* PodSetupCompleteViewController.swift */; };
 		C1941151228DBF2100E886DD /* ExpirationReminderDateTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1941150228DBF2100E886DD /* ExpirationReminderDateTableViewCell.swift */; };
@@ -118,6 +112,10 @@
 		C1ACF44222A1FC1F00F7DDB4 /* PodDoseProgressTimerEstimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1ACF44122A1FC1F00F7DDB4 /* PodDoseProgressTimerEstimator.swift */; };
 		C1ACF44422A200B100F7DDB4 /* UnfinalizedDose.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1ACF44322A200B100F7DDB4 /* UnfinalizedDose.swift */; };
 		C1ACF44522A200D700F7DDB4 /* NumberFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1ACF43622A04B4800F7DDB4 /* NumberFormatter.swift */; };
+		C1BBA85B25BA1EC400AD4CDE /* INSSDK.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = C1BBA83D25BA065000AD4CDE /* INSSDK.xcframework */; };
+		C1BBA85C25BA1EC500AD4CDE /* INSSDK.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = C1BBA83D25BA065000AD4CDE /* INSSDK.xcframework */; };
+		C1BBA86525BA1F6C00AD4CDE /* PodSDK.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = C11097CD238F14A4004F1A04 /* PodSDK.xcframework */; };
+		C1BBA86A25BA1F6D00AD4CDE /* PodSDK.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = C11097CD238F14A4004F1A04 /* PodSDK.xcframework */; };
 		C1BC259C2314604800E80E3F /* DashPumpManagerError.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1BC259B2314604800E80E3F /* DashPumpManagerError.swift */; };
 		C1C72D8B241568E700DB224B /* DashSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1C72D8A241568E700DB224B /* DashSettingsView.swift */; };
 		C1C799F424C7749B008E0A1A /* FrameworkLocalText.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1C799F324C7749B008E0A1A /* FrameworkLocalText.swift */; };
@@ -142,8 +140,6 @@
 		C1FE2E3D22EA0B570035DCA0 /* LoopKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C1FE2E3922EA0B360035DCA0 /* LoopKit.framework */; };
 		C1FE2E3E22EA0B5A0035DCA0 /* LoopKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C1FE2E3922EA0B360035DCA0 /* LoopKit.framework */; };
 		C1FE2E3F22EA0B5D0035DCA0 /* LoopKitUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C1FE2E3B22EA0B360035DCA0 /* LoopKitUI.framework */; };
-		C1FE2E5822EA0DDC0035DCA0 /* INSSDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C1FE2E5622EA0DDB0035DCA0 /* INSSDK.framework */; };
-		C1FE2E5A22EA0DEA0035DCA0 /* INSSDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C1FE2E5622EA0DDB0035DCA0 /* INSSDK.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -224,8 +220,6 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				C1245D4E24B8D59B0065120F /* PodSDK.xcframework in CopyFiles */,
-				C176FE3624350651005258CD /* INSSDK.framework in CopyFiles */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -329,6 +323,7 @@
 		C1ACF43E22A1F9A700F7DDB4 /* OSLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSLog.swift; sourceTree = "<group>"; };
 		C1ACF44122A1FC1F00F7DDB4 /* PodDoseProgressTimerEstimator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PodDoseProgressTimerEstimator.swift; sourceTree = "<group>"; };
 		C1ACF44322A200B100F7DDB4 /* UnfinalizedDose.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnfinalizedDose.swift; sourceTree = "<group>"; };
+		C1BBA83D25BA065000AD4CDE /* INSSDK.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = INSSDK.xcframework; path = "dash-sdk-ios/frameworks/INSSDK.xcframework"; sourceTree = "<group>"; };
 		C1BC259B2314604800E80E3F /* DashPumpManagerError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashPumpManagerError.swift; sourceTree = "<group>"; };
 		C1C72D8A241568E700DB224B /* DashSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashSettingsView.swift; sourceTree = "<group>"; };
 		C1C799F324C7749B008E0A1A /* FrameworkLocalText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrameworkLocalText.swift; sourceTree = "<group>"; };
@@ -352,7 +347,6 @@
 		C1FDF4AB235EC930008B0251 /* HUDAssets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = HUDAssets.xcassets; sourceTree = "<group>"; };
 		C1FE2E3922EA0B360035DCA0 /* LoopKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = LoopKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C1FE2E3B22EA0B360035DCA0 /* LoopKitUI.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = LoopKitUI.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		C1FE2E5622EA0DDB0035DCA0 /* INSSDK.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = INSSDK.framework; path = "dash-sdk-ios/frameworks/INSSDK.framework"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -371,7 +365,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				C10CFCFD2584137200CD89D8 /* LoopKit.framework in Frameworks */,
-				C10CFCFE2584137200CD89D8 /* INSSDK.framework in Frameworks */,
 				C10CFCFF2584137200CD89D8 /* LoopKitUI.framework in Frameworks */,
 				C10CFD002584137200CD89D8 /* DashKit.framework in Frameworks */,
 				C10CFD012584137200CD89D8 /* DashKitUI.framework in Frameworks */,
@@ -383,7 +376,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				C1FE2E3A22EA0B360035DCA0 /* LoopKit.framework in Frameworks */,
-				C1FE2E5A22EA0DEA0035DCA0 /* INSSDK.framework in Frameworks */,
 				C1FE2E3C22EA0B360035DCA0 /* LoopKitUI.framework in Frameworks */,
 				C16DA83622E7C6F2008624C2 /* DashKit.framework in Frameworks */,
 				C16DA85822E93973008624C2 /* DashKitUI.framework in Frameworks */,
@@ -402,9 +394,9 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				C1FE2E5822EA0DDC0035DCA0 /* INSSDK.framework in Frameworks */,
+				C1BBA85C25BA1EC500AD4CDE /* INSSDK.xcframework in Frameworks */,
+				C1BBA86A25BA1F6D00AD4CDE /* PodSDK.xcframework in Frameworks */,
 				C1FE2E3D22EA0B570035DCA0 /* LoopKit.framework in Frameworks */,
-				C11097CE238F14A4004F1A04 /* PodSDK.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -412,9 +404,9 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C1BBA85B25BA1EC400AD4CDE /* INSSDK.xcframework in Frameworks */,
+				C1BBA86525BA1F6C00AD4CDE /* PodSDK.xcframework in Frameworks */,
 				C1E753E3226928F700A0BC48 /* DashKit.framework in Frameworks */,
-				C176FE3524350581005258CD /* INSSDK.framework in Frameworks */,
-				C1245D4D24B8D5510065120F /* PodSDK.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -424,8 +416,8 @@
 		C107D10C22692AE700D63775 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				C1BBA83D25BA065000AD4CDE /* INSSDK.xcframework */,
 				C11097CD238F14A4004F1A04 /* PodSDK.xcframework */,
-				C1FE2E5622EA0DDB0035DCA0 /* INSSDK.framework */,
 				C1FE2E3922EA0B360035DCA0 /* LoopKit.framework */,
 				C1FE2E3B22EA0B360035DCA0 /* LoopKitUI.framework */,
 			);
@@ -979,7 +971,7 @@
 				"$(BUILT_PRODUCTS_DIR)/DashKit.framework/DashKit",
 				"$(BUILT_PRODUCTS_DIR)/DashKitUI.framework/DashKitUI",
 				"$(BUILT_PRODUCTS_DIR)/RxSwift.framework/RxSwift",
-				"$(SRCROOT)/dash-sdk-ios/frameworks/INSSDK.framework/INSSDK",
+				"$(SRCROOT)/dash-sdk-ios/frameworks/INSSDK.xcframework/ios-arm64/INSSDK.framework/INSSDK",
 				"$(SRCROOT)/dash-sdk-ios/frameworks/PodSDK.xcframework/ios-arm64/PodSDK.framework/PodSDK",
 				"$(BUILT_PRODUCTS_DIR)/MKRingProgressView.framework/MKRingProgressView",
 			);
@@ -1021,7 +1013,7 @@
 				"$(BUILT_PRODUCTS_DIR)/DashKit.framework/DashKit",
 				"$(BUILT_PRODUCTS_DIR)/DashKitUI.framework/DashKitUI",
 				"$(BUILT_PRODUCTS_DIR)/RxSwift.framework/RxSwift",
-				"$(SRCROOT)/dash-sdk-ios/frameworks/INSSDK.framework/INSSDK",
+				"$(SRCROOT)/dash-sdk-ios/frameworks/INSSDK.xcframework/ios-arm64/INSSDK.framework/INSSDK",
 				"$(SRCROOT)/dash-sdk-ios/frameworks/PodSDK.xcframework/ios-arm64/PodSDK.framework/PodSDK",
 				"$(BUILT_PRODUCTS_DIR)/MKRingProgressView.framework/MKRingProgressView",
 			);


### PR DESCRIPTION
This takes the existing INSSDK.framework and converts it into an xcframework. The work was done manually, with some plist editing and using lipo to extract the correct architectures and put them into platform specific new frameworks. Ran tests on the simulator, and built to actual device and tested PumpManager setup.