### PR TITLE
[LOOP-3257] inset the round card title for all devices to align with card content

### DIFF
--- a/DashKitUI/Views/DesignElements/RoundedCard.swift
+++ b/DashKitUI/Views/DesignElements/RoundedCard.swift
@@ -71,19 +71,19 @@ public struct RoundedCardValueRow: View {
 }
 
 struct RoundedCard<Content: View>: View {
-    var content: () -> Content
+    var content: () -> Content?
     var alignment: HorizontalAlignment
     var title: String?
     var footer: String?
     @Environment(\.horizontalSizeClass) var horizontalSizeClass
 
-    init(title: String? = nil, footer: String? = nil, alignment: HorizontalAlignment = .leading, @ViewBuilder content: @escaping () -> Content) {
+    init(title: String? = nil, footer: String? = nil, alignment: HorizontalAlignment = .leading, @ViewBuilder content: @escaping () -> Content? = { nil }) {
         self.content = content
         self.alignment = alignment
         self.title = title
         self.footer = footer
     }
-    
+
     var body: some View {
         VStack(spacing: 10) {
             if let title = title {
@@ -91,24 +91,27 @@ struct RoundedCard<Content: View>: View {
                     .frame(maxWidth: .infinity, alignment: Alignment(horizontal: .leading, vertical: .center))
                     .padding(.leading, titleInset)
             }
-            
-            if isCompact {
-                VStack(spacing: 0) {
-                    borderLine
+
+            if content() != nil {
+                if isCompact {
+                    VStack(spacing: 0) {
+                        borderLine
+                        VStack(alignment: alignment, content: content)
+                            .frame(maxWidth: .infinity, alignment: Alignment(horizontal: alignment, vertical: .center))
+                            .padding(inset)
+                            .background(Color(.secondarySystemGroupedBackground))
+                        borderLine
+                    }
+                } else {
                     VStack(alignment: alignment, content: content)
                         .frame(maxWidth: .infinity, alignment: Alignment(horizontal: alignment, vertical: .center))
-                        .padding(inset)
+                        .padding(.horizontal, inset)
+                        .padding(.vertical, 10)
                         .background(Color(.secondarySystemGroupedBackground))
-                    borderLine
+                        .clipShape(RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
                 }
-            } else {
-                VStack(alignment: alignment, content: content)
-                    .frame(maxWidth: .infinity, alignment: Alignment(horizontal: alignment, vertical: .center))
-                    .padding(.horizontal, inset)
-                    .padding(.vertical, 10)
-                    .background(Color(.secondarySystemGroupedBackground))
-                    .clipShape(RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
             }
+
             if let footer = footer {
                 RoundedCardFooter(footer)
                     .frame(maxWidth: .infinity, alignment: Alignment(horizontal: alignment, vertical: .center))
@@ -127,7 +130,7 @@ struct RoundedCard<Content: View>: View {
     }
     
     private var titleInset: CGFloat {
-        return inset
+        return isCompact ? inset : 0
     }
     
     private var padding: CGFloat {

--- a/DashKitUI/Views/DesignElements/RoundedCard.swift
+++ b/DashKitUI/Views/DesignElements/RoundedCard.swift
@@ -127,7 +127,7 @@ struct RoundedCard<Content: View>: View {
     }
     
     private var titleInset: CGFloat {
-        return isCompact ? inset : 0
+        return inset
     }
     
     private var padding: CGFloat {

--- a/DashKitUI/Views/NotificationSettingsView.swift
+++ b/DashKitUI/Views/NotificationSettingsView.swift
@@ -118,6 +118,19 @@ struct NotificationSettingsView: View {
 
 struct NotificationSettingsView_Previews: PreviewProvider {
     static var previews: some View {
-        NotificationSettingsView(dateFormatter: DateFormatter(), expirationReminderDefault: .constant(2), scheduledReminderDate: Date(), allowedScheduledReminderDates: [Date()], lowReservoirReminderValue: 20)
+        return Group {
+            NavigationView {
+                NotificationSettingsView(dateFormatter: DateFormatter(), expirationReminderDefault: .constant(2), scheduledReminderDate: Date(), allowedScheduledReminderDates: [Date()], lowReservoirReminderValue: 20)
+                    .previewDevice(PreviewDevice(rawValue:"iPod touch (7th generation)"))
+                    .previewDisplayName("iPod touch (7th generation)")
+            }
+
+            NavigationView {
+                NotificationSettingsView(dateFormatter: DateFormatter(), expirationReminderDefault: .constant(2), scheduledReminderDate: Date(), allowedScheduledReminderDates: [Date()], lowReservoirReminderValue: 20)
+                    .colorScheme(.dark)
+                    .previewDevice(PreviewDevice(rawValue: "iPhone XS Max"))
+                    .previewDisplayName("iPhone XS Max - Dark")
+            }
+        }
     }
 }

--- a/DashKitUI/Views/NotificationSettingsView.swift
+++ b/DashKitUI/Views/NotificationSettingsView.swift
@@ -12,7 +12,7 @@ import LoopKitUI
 import HealthKit
 
 struct NotificationSettingsView: View {
-    
+
     var dateFormatter: DateFormatter
     
     @Binding var expirationReminderDefault: Int
@@ -54,12 +54,10 @@ struct NotificationSettingsView: View {
                 lowReservoirValueRow
             }
 
-            VStack(alignment: .leading) {
-                RoundedCardTitle(LocalizedString("Critical Alerts", comment: "Title for critical alerts description"))
-                    .padding(.bottom, 1)
-                RoundedCardFooter(LocalizedString("The reminders above will not sound if your device is in Silent or Do Not Disturb mode.\n\nThere are other critical Pod alerts and alarms that will sound even if you device is set to Silent or Do Not Disturb mode.", comment: "Description text for critical alerts"))
-            }
-            .padding(.horizontal, 16)
+            RoundedCard<EmptyView>(
+                title: LocalizedString("Critical Alerts", comment: "Title for critical alerts description"),
+                footer: LocalizedString("The reminders above will not sound if your device is in Silent or Do Not Disturb mode.\n\nThere are other critical Pod alerts and alarms that will sound even if you device is set to Silent or Do Not Disturb mode.", comment: "Description text for critical alerts")
+            )
         }
         .navigationBarTitle(LocalizedString("Notification Settings", comment: "navigation title for notification settings"))
     }


### PR DESCRIPTION
https://tidepool.atlassian.net/browse/LOOP-3257

![Screen Shot 2021-08-23 at 09 47 53](https://user-images.githubusercontent.com/152359/130450447-9a581526-5218-4b20-9c72-2353eb958ec3.png)
![Screen Shot 2021-08-23 at 09 51 47](https://user-images.githubusercontent.com/152359/130450451-1e52f7d4-ae15-47f9-ae92-a34602017f77.png)
