### PR TITLE
LOOP-3908 Update hkdevice strings

### DIFF
--- a/DashKit/DashPumpManager.swift
+++ b/DashKit/DashPumpManager.swift
@@ -38,7 +38,7 @@ open class DashPumpManager: PumpManager {
     }
     
     open var managerIdentifier: String {
-        return "OmnipodDash"
+        return "Omnipod"
     }
 
     open var registrationManager: PDMRegistrator {
@@ -404,7 +404,7 @@ open class DashPumpManager: PumpManager {
         return HKDevice(
             name: managerIdentifier,
             manufacturer: "Insulet",
-            model: "DASH",
+            model: "Omnipod 5",
             hardwareVersion: hardwareVersion,
             firmwareVersion: firmwareVersion,
             softwareVersion: String(DashKitVersionNumber),

--- a/DashKitPlugin/Info.plist
+++ b/DashKitPlugin/Info.plist
@@ -5,7 +5,7 @@
 	<key>com.loopkit.Loop.PumpManagerDisplayName</key>
 	<string>Omnipod</string>
 	<key>com.loopkit.Loop.PumpManagerIdentifier</key>
-	<string>OmnipodDash</string>
+	<string>Omnipod</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleExecutable</key>


### PR DESCRIPTION
https://tidepool.atlassian.net/browse/LOOP-3908

Update hkdevice strings, and change device identifier to not reference Dash.  Any existing instances of Loop with paired "OmnipodDash" pump, Loop will not be able to load, so re-pairing will be necessary.