### PR TITLE
COASTAL-651: Adds PersistedAlertStore for looking up outstanding alerts

### DIFF
--- a/DashKitTests/DashPumpManagerTests.swift
+++ b/DashKitTests/DashPumpManagerTests.swift
@@ -952,4 +952,8 @@ extension DashPumpManagerTests: PumpManagerDelegate {
 
     func deviceManager(_ manager: DeviceManager, logEventForDeviceIdentifier deviceIdentifier: String?, type: DeviceLogEntryType, message: String, completion: ((Error?) -> Void)?) {
     }
+    
+    func lookupOutstandingAlerts(managerIdentifier: String, completion: @escaping (Result<[PersistedAlert], Error>) -> Void) {
+        
+    }
 }

--- a/DashKitTests/DashPumpManagerTests.swift
+++ b/DashKitTests/DashPumpManagerTests.swift
@@ -953,7 +953,9 @@ extension DashPumpManagerTests: PumpManagerDelegate {
     func deviceManager(_ manager: DeviceManager, logEventForDeviceIdentifier deviceIdentifier: String?, type: DeviceLogEntryType, message: String, completion: ((Error?) -> Void)?) {
     }
     
-    func lookupOutstandingAlerts(managerIdentifier: String, completion: @escaping (Result<[PersistedAlert], Error>) -> Void) {
-        
+    func lookupAllUnretracted(managerIdentifier: String, completion: @escaping (Result<[PersistedAlert], Error>) -> Void) {
+    }
+    
+    func lookupAllUnacknowledgedUnretracted(managerIdentifier: String, completion: @escaping (Result<[PersistedAlert], Error>) -> Void) {
     }
 }


### PR DESCRIPTION
Adds ability to query CoreData for all outstanding (i.e. "unretracted") alerts from a given `managerIdentifier`.

https://tidepool.atlassian.net/browse/COASTAL-651

LWPR: https://github.com/tidepool-org/LoopWorkspace/pull/780