### PR TITLE
COASTAL-625: Relax requirement that HUDProvider needs to provide LevelHUDView

### DIFF
--- a/DashKitUI/PumpManager/DashHUDProvider.swift
+++ b/DashKitUI/PumpManager/DashHUDProvider.swift
@@ -53,7 +53,7 @@ internal class DashHUDProvider: NSObject, HUDProvider {
         self.pumpManager.addPodStatusObserver(self, queue: .main)
     }
 
-    public func createHUDView() -> LevelHUDView? {
+    public func createHUDView() -> BaseHUDView? {
         reservoirView = OmnipodReservoirView.instantiate()
         updateReservoirView()
 

--- a/DashKitUI/PumpManager/DashPumpManager+UI.swift
+++ b/DashKitUI/PumpManager/DashPumpManager+UI.swift
@@ -40,7 +40,7 @@ extension DashPumpManager: PumpManagerUI {
         return DashHUDProvider(pumpManager: self, bluetoothProvider: bluetoothProvider, colorPalette: colorPalette, allowedInsulinTypes: allowedInsulinTypes)
     }
 
-    public static func createHUDView(rawValue: HUDProvider.HUDViewRawState) -> LevelHUDView? {
+    public static func createHUDView(rawValue: HUDProvider.HUDViewRawState) -> BaseHUDView? {
         return DashHUDProvider.createHUDView(rawValue: rawValue)
     }
 


### PR DESCRIPTION
LevelHUDView is for providing a view that displays a thermometer level, which not all Pumps may provide.  This relaxes the requirement and just requires returning a BaseHUDView.

https://tidepool.atlassian.net/browse/COASTAL-625